### PR TITLE
Update versions and URLs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,8 +7,8 @@ This is a GitHub Actions workflow that benchmarks the performance of MiGraphX, a
 </p>
 
 - ## Trigger
-    Note: Right now its not working because [benchmark.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/benchmark.yaml) workflow needed to be updated.
-     - The workflow will be triggered on workflow dispatch event from caller workflow [benchmark.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/benchmark.yaml)
+    Note: Right now its not working because [benchmark.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/benchmark.yaml) workflow needed to be updated.
+     - The workflow will be triggered on workflow dispatch event from caller workflow [benchmark.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/benchmark.yaml)
 
 - ## Input Parameters
     The workflow uses the following input parameters:
@@ -38,7 +38,7 @@ This is a GitHub Actions workflow that benchmarks the performance of MiGraphX, a
 
      - `git_push_result`: This job pushes the benchmark results to a GitHub repository. It runs on a self-hosted machine and depends on the `run_benchmark` job. It checks out the results repository, executes two Python scripts to generate a report, and pushes the report to the results repository. The job sets no outputs.
 
-    For more details, please refer to the [benchmarks.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/benchmarks.yml) file in the repository.
+    For more details, please refer to the [benchmarks.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/benchmarks.yml) file in the repository.
 
 ---
 ## `history.yml`
@@ -49,7 +49,7 @@ This workflow analyzes the historical performance of the MIGraphX project by run
 
 - ## Trigger
      - The workflow will be triggered on workflow dispatch event from caller workflow 
-[history.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/history.yaml) 
+[history.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/history.yaml) 
 
 - ## Input Parameters
     The workflow uses the following input parameters:
@@ -88,7 +88,7 @@ This workflow analyzes the historical performance of the MIGraphX project by run
 
      - `Get link to results repository`: This step prints a link to the historical analysis report repository specified in the inputs, which can be used to access the report.
 
-    For more details, please refer to the [history.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/history.yml) file in the repository.
+    For more details, please refer to the [history.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/history.yml) file in the repository.
 
 ---
 
@@ -100,7 +100,7 @@ Overall, this workflow is designed for running performance tests on the MIGraphX
 
 - ## Trigger
      - The workflow will be triggered on workflow dispatch event from caller workflow 
-[performance.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/performance.yaml) 
+[performance.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/performance.yaml) 
 
 - ## Input Parameters
     The workflow uses the following input parameters:
@@ -199,7 +199,7 @@ Overall, this workflow is designed for running performance tests on the MIGraphX
 
 
 
-    For more details, please refer to the [perf-test.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/perf-test.yml) file in the repository.
+    For more details, please refer to the [perf-test.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/perf-test.yml) file in the repository.
 
 
 ---
@@ -212,7 +212,7 @@ This workflow automates the process of building a Docker image for the ROCm (Rad
 
 - ## Trigger
     - The workflow will be triggered on workflow dispatch event from caller workflow 
-[rocm-image-release.yaml](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/rocm-image-release.yaml) 
+[rocm-image-release.yaml](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/rocm-image-release.yaml) 
 
 - ## Input Parameters
     The workflow uses the following input parameters:
@@ -241,7 +241,7 @@ This workflow automates the process of building a Docker image for the ROCm (Rad
 
      - `build_image`: This job builds the ROCm Docker image if the `check_image_version` job determined that a new image needs to be built. This job checks out the benchmark utilities repository, sets environment variables based on the input parameters, and runs a script to build the Docker image.
 
-    For more details, please refer to the [rocm-release.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/rocm-release.yml) file in the repository.
+    For more details, please refer to the [rocm-release.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/rocm-release.yml) file in the repository.
 
 
 ---

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -48,10 +48,10 @@ jobs:
     if: ${{ needs.check_image_version.outputs.image == 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Checkout Utils
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.script_repo }}
           path: ${{ env.SCRIPT_PATH }}
@@ -70,7 +70,7 @@ jobs:
     needs: build_image
     steps:
       - name: Checkout Utils
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.script_repo }}
           path: ${{ env.SCRIPT_PATH }}

--- a/.github/workflows/history.yml
+++ b/.github/workflows/history.yml
@@ -49,17 +49,17 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       
       - name: Checkout utils
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.benchmark_utils_repo }}
           path: ${{ env.UTILS_DIR }}
           token: ${{ secrets.gh_token }}
       
       - name: Checkout report's repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.history_repo }}
           path: ${{ env.REPORTS_DIR }}

--- a/.github/workflows/miopen-db.yml
+++ b/.github/workflows/miopen-db.yml
@@ -73,7 +73,7 @@ jobs:
       database: ${{ steps.check_database.outputs.database }}
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.miopen_db_repo }}
           path: ${{ env.MIOPEN_PATH }}
@@ -92,7 +92,7 @@ jobs:
     if: ( needs.check_database.outputs.database == 'true' && needs.check_image_version.outputs.image == 'true' )
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.miopen_db_repo }}
           path: ${{ env.SCRIPT_PATH}}
@@ -118,7 +118,7 @@ jobs:
     needs: [create_database, check_gpu_name]
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.miopen_db_repo }}
           path: ${{ env.MIOPEN_PATH }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -85,10 +85,10 @@ jobs:
           echo "TEST_RESULTS_PATH=$(echo "$TEST_RESULTS_PATH-$PR_ID")" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Checkout utils
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.benchmark_utils_repo }}
           path: ${{ env.UTILS_DIR }}
@@ -141,7 +141,7 @@ jobs:
 
       - name: Checkout report's repo
         if: ${{ github.event_name == 'schedule' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.performance_reports_repo }}
           path: ${{ env.REPORTS_DIR }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Create a comment on PR
         if: ${{ github.event_name != 'schedule' && github.event_name == 'pull_request' && github.event.action != 'closed'}}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v2.8
         with:
           header: performance
           GITHUB_TOKEN: ${{ secrets.gh_token }}
@@ -193,7 +193,7 @@ jobs:
 
       - name: Create accuracy comment on PR
         if: ${{ github.event_name != 'schedule' && github.event_name == 'pull_request' && github.event.action != 'closed'}}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v2.8
         with:
           header: accuracy
           GITHUB_TOKEN: ${{ secrets.gh_token }}
@@ -227,7 +227,7 @@ jobs:
 
       - name : Checkout for backup
         if: ${{ github.event_name == 'schedule' || ( github.event.action == 'closed' && github.event.pull_request.merged == true) }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.performance_backup_repo }}
           path: ${{ env.PERFORMANCE_DIR }}

--- a/.github/workflows/rocm-release.yml
+++ b/.github/workflows/rocm-release.yml
@@ -59,10 +59,10 @@ jobs:
     if: ${{ needs.check_image_version.outputs.image == 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Checkout Utils
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: ${{ inputs.benchmark-utils_repo }}
           path: ${{ env.UTILS_DIR }}

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This directory contains reusable workflows in subdirectory that can be used in different workflows. The reusable workflows are designed to automate repetitive tasks in a software development workflow, such as deploying the application to different environments, checking the code for errors, and generating reports.
 
 ## List of reusable workflows
-- [benchmarks.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/benchmarks.yml) caller of this workflow is [here](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/benchmark.yaml)
-- [history.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/history.yml) caller of this workflow is [here](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/history.yaml)
-- [perf-test.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/perf-test.yml) caller of this workflow is [here](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/performance.yaml)
-- [rocm-release.yml](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/blob/main/.github/workflows/rocm-release.yml) caller of this workflow is [here](https://github.com/ROCmSoftwarePlatform/AMDMIGraphX/blob/develop/.github/workflows/rocm-image-release.yaml)
+- [benchmarks.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/benchmarks.yml) caller of this workflow is [here](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/benchmark.yaml)
+- [history.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/history.yml) caller of this workflow is [here](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/history.yaml)
+- [perf-test.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/perf-test.yml) caller of this workflow is [here](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/performance.yaml)
+- [rocm-release.yml](https://github.com/ROCm/migraphx-benchmark/blob/main/.github/workflows/rocm-release.yml) caller of this workflow is [here](https://github.com/ROCm/AMDMIGraphX/blob/develop/.github/workflows/rocm-image-release.yaml)
 
-Each reusable workflow is described in more details [here](https://github.com/ROCmSoftwarePlatform/migraphx-benchmark/tree/main/.github/workflows)
+Each reusable workflow is described in more details [here](https://github.com/ROCm/migraphx-benchmark/tree/main/.github/workflows)
 
 ---


### PR DESCRIPTION
Updating versions of actions/checkout and `sticky-pull-request-commenet` to avoid node.js 16 deprecation warnings. 
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/