### PR TITLE
Fix for EBUSY after canceled run, selecting new runners

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   check_image_version:
     name: Check Image Version
-    runs-on: self-hosted
+    runs-on: [self-hosted,performance]
     outputs:
       image: ${{ steps.check_image.outputs.image }}
     steps:
@@ -43,7 +43,7 @@ jobs:
           fi
   build_image:
     name: Build New Image
-    runs-on: self-hosted
+    runs-on: [self-hosted,performance]
     needs: check_image_version
     if: ${{ needs.check_image_version.outputs.image == 'true' }}
     steps:
@@ -63,7 +63,7 @@ jobs:
           docker build --build-arg BASE_IMAGE="rocm/pytorch:rocm${{ inputs.rocm_version }}_ubuntu20.04_py3.7_pytorch_1.10.0" -t "migraphx-ort:$(date +%Y%m%d)" --no-cache -f Ort.Dockerfile .
   run_benchmark:
     name: Run benchmark
-    runs-on: self-hosted
+    runs-on: [self-hosted,performance]
     if: ${{ always() }}
     outputs:
       result_time_start: ${{ steps.result_time.outputs.result_time_start }}
@@ -104,7 +104,7 @@ jobs:
           
   git_push_result:
     name: Push result to Github
-    runs-on: self-hosted
+    runs-on: [self-hosted,performance]
     if: ${{ always() }}
     needs: run_benchmark
     steps:

--- a/.github/workflows/history.yml
+++ b/.github/workflows/history.yml
@@ -45,9 +45,9 @@ env:
 jobs:
   performance_test:
     name: MIGraphX results between dates
-    runs-on: self-hosted
+    runs-on: [self-hosted,performance]
     steps:
-
+      
       - name: Checkout code
         uses: actions/checkout@v4.1.1
       

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -153,6 +153,9 @@ jobs:
         if: ${{ github.event.action != 'closed' }}
         run: >
           docker run -e TZ=America/Chicago
+          --name perf-test-$GITHUB_RUN_ID
+          --cpuset-cpus=${{ env.CPU }}
+          -e ROCR_VISIBLE_DEVICES=${{ env.GPU }}
           -e TARGET=gpu
           -e PYTHONPATH=/src/AMDMIGraphX/build/lib
           -e USE_RBUILD=1

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -72,6 +72,17 @@ jobs:
     outputs:
       git_sha: ${{ steps.git_sha.outputs.git_sha }}
     steps:
+      - name: Clean up canceled runs
+        run: |
+          wf_id=$(curl -H "Authorization: token ${{ secrets.gh_token }}" \
+          ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows \
+          | jq -r '.workflows[] | {id, name}| select(.name == "${{ github.workflow }}") | .id')
+          cancel_id=$(curl -H "Authorization: token ${{ secrets.gh_token }}" \
+          ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/$wf_id/runs?per_page=10 \
+          | jq -r '.workflow_runs[] | {id, run_number, conclusion} | select(.conclusion == "cancelled") | {id, run_number}' \
+          | jq -n 'input | .id')
+          docker stop perf-test-$cancel_id || true
+      
       - name: Get runner ID
         run: |
           case "$RUNNER_NAME" in

--- a/.github/workflows/rocMLIR_sync.yml
+++ b/.github/workflows/rocMLIR_sync.yml
@@ -43,8 +43,19 @@ env:
 jobs:
   sync_rocMLIR:
     name: Sync rocMLIR and run extended accuracy
-    runs-on: self-hosted
-    steps:      
+    runs-on: [self-hosted,performance]
+    steps:
+      - name: Clean up canceled runs
+        run: |
+          wf_id=$(curl -H "Authorization: token ${{ secrets.gh_token }}" \
+          ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows \
+          | jq -r '.workflows[] | {id, name}| select(.name == "${{ github.workflow }}") | .id')
+          cancel_id=$(curl -H "Authorization: token ${{ secrets.gh_token }}" \
+          ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/$wf_id/runs?per_page=10 \
+          | jq -r '.workflow_runs[] | {id, run_number, conclusion} | select(.conclusion == "cancelled") | {id, run_number}' \
+          | jq -n 'input | .id')
+          docker stop perf-test-$cancel_id || true
+              
       - name: Get date
         if: ${{ github.event_name != 'pull_request' }}
         run: echo todays_date="$(date +'%Y-%m-%d')" >> $GITHUB_ENV

--- a/.github/workflows/rocm-release.yml
+++ b/.github/workflows/rocm-release.yml
@@ -58,7 +58,7 @@ jobs:
           fi
   build_image:
     name: Build New Image
-    runs-on: self-hosted
+    runs-on: [self-hosted,performance]
     needs: check_image_version
     if: ${{ needs.check_image_version.outputs.image == 'true' }}
     steps:


### PR DESCRIPTION
Added new step to cleanup after canceled runs and prevent EBUSY errors on consecutive runs.
Also, directing workflows to use new runner.