### PR TITLE
Change commit id extract, fix detached id

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -146,7 +146,10 @@ jobs:
         id: git_sha
         run: |
           cd $GITHUB_WORKSPACE
-          SHA=$(git log | head -1 | awk '{print $2}' | cut -c 1-6)
+          SHA=$(git log | head -5 | grep Merge | awk '{print $2}' | cut -c 1-6)
+          if [ -z "$SHA" ]; then
+            SHA=$(git log | head -5 | grep -m 1 "^commit" | awk '{print $2}' | cut -c 1-6)
+          fi
           echo "git_sha=$SHA" >> $GITHUB_OUTPUT
 
       - name: Docker build


### PR DESCRIPTION
This fixes the issue with bad commit id path in migraphx-reports.
PR commit that triggers performance test workflow is in detached state and commit id read in workflow is not matching commit id that is used for building MIGraphX and presented in comment table.