### PR TITLE
Sanitize branch name to prevent code injection

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -132,7 +132,8 @@ jobs:
       - name: Update PR env
         if: ${{ github.event_name == 'pull_request_target'}}
         run: |
-          echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_ENV
+          sanitized_branch_name=$(echo "${{ github.head_ref }}" | sed 's/[^a-zA-Z0-9_]/-/g')
+          echo "BRANCH_NAME=$sanitized_branch_name" >> $GITHUB_ENV
           echo "TEST_RESULTS_PATH=$(echo "$TEST_RESULTS_PATH-$PR_ID")" >> $GITHUB_ENV
 
       - name: Checkout code


### PR DESCRIPTION
Simple check that replaces all non-alphanumerical characters (except underscore) in branch name to dash.
This should prevent code injection via crafted branch name