### PR TITLE
set migraphx-driver dynamically by finding the path in /opt/rocm instead of using the fixed one

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -173,7 +173,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && SAVED_MODELS=$GITHUB_WORKSPACE DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} && chmod 777 ${{ env.TEST_RESULTS_PATH }} "
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && SAVED_MODELS=${{ env.TEST_RESULTS_PATH }} DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} && chmod 777 ${{ env.TEST_RESULTS_PATH }} "
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -35,6 +35,18 @@ on:
         type: string
         description: Repository for backup
         required: true
+      model_path:
+        type: string
+        description: Host path to NFS-backed models (ARC runner mount)
+        required: false
+      perf_workspace:
+        type: string
+        description: Writable NFS-backed workspace for reports/scratch (ARC runner mount)
+        required: false
+      runs_on:
+        type: string
+        description: Self-hosted runner label (ARC scale set linux-migraphx-mi250-1)
+        required: false
     secrets:
       BENCHMARK_UTILS_READ_TOKEN:
         description: Token with read access to benchmark utils repo
@@ -46,13 +58,13 @@ env:
   MIOPENTUNE: miopen-dbs/rocm${{ inputs.rocm_release }}
   PR_ID: ${{ github.event.number }}
   BRANCH_NAME: develop
-  TEST_RESULTS_PATH: /usr/share/migraphx/${{ inputs.organization }}/test-results
-  MIGRAPHX_PATH: /usr/share/migraphx/${{ inputs.organization }}
+  TEST_RESULTS_PATH: ${{ inputs.perf_workspace }}/${{ inputs.organization }}/test-results
+  MIGRAPHX_PATH: ${{ inputs.perf_workspace }}/migraphx/${{ inputs.organization }}
 
 jobs:
   performance_test:
     name: MIGraphX Performance
-    runs-on: [self-hosted, "linux-migraphx-mi250-1"]
+    runs-on: [self-hosted, "${{ inputs.runs_on }}"]
     outputs:
       git_sha: ${{ steps.git_sha.outputs.git_sha }}
     steps:
@@ -201,7 +213,7 @@ jobs:
           --device=/dev/kfd
           --network=host
           --group-add=video
-          -v /usr/share/migraphx/models:/models:ro
+          -v ${{ inputs.models_path }}:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           --workdir /migraphx/sh

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -64,7 +64,7 @@ env:
 jobs:
   performance_test:
     name: MIGraphX Performance
-    runs-on: [self-hosted, "${{ inputs.runs_on }}"]
+    runs-on: ["${{ inputs.runs_on }}"]
     outputs:
       git_sha: ${{ steps.git_sha.outputs.git_sha }}
     steps:

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -143,10 +143,6 @@ jobs:
           path: ${{ env.UTILS_DIR }}
           ssh-key: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
 
-      - name: Little Debug
-        run: |
-          ls -l $GITHUB_WORKSPACE
-
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
         run: >
@@ -167,7 +163,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./build_migraphx.sh && ./performance_tests.sh ${{ inputs.model_timeout }}"
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && ./performance_tests.sh ${{ inputs.model_timeout }}"
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -148,8 +148,8 @@ jobs:
         run: |
           ls -la  ${{ inputs.model_path }}
           echo "model_path=${{ inputs.model_path }}" >> $GITHUB_ENV
-          ls -la env.TEST_RESULTS_PATH
-          echo "results_path=$(echo "env.TEST_RESULTS_PATH")" >> $GITHUB_ENV
+          ls -la /mnt/migraphx-perf-work
+          echo "results_path=${{ env.TEST_RESULTS_PATH }}<<" >> $GITHUB_ENV ||true
 
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -143,6 +143,13 @@ jobs:
           path: ${{ env.UTILS_DIR }}
           ssh-key: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
 
+      - name: Little debug
+          run: |
+              ls -la  ${{ inputs.model_path }}
+              echo "model_path=${{ inputs.model_path }}" >> $GITHUB_ENV
+              ls -la env.TEST_RESULTS_PATH
+              echo "results_path=$(echo "env.TEST_RESULTS_PATH")" >> $GITHUB_ENV
+
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
         run: >

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -52,7 +52,7 @@ env:
 jobs:
   performance_test:
     name: MIGraphX Performance
-    runs-on: ubuntu-latest # [self-hosted, performance]
+    runs-on: [self-hosted, "linux-migraphx-mi250-1"]
     outputs:
       git_sha: ${{ steps.git_sha.outputs.git_sha }}
     steps:
@@ -88,6 +88,10 @@ jobs:
             "c13-38_4")
               GPU=4
               CPU="32-63"
+              ;;
+            "linux-migraphx-mi250-1")
+              GPU=0
+              CPU="0-31"
               ;;
             *)
               echo "Unknown RUNNER_ID: $RUNNER_NAME"

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Download Resnet50
         if: ${{ github.event.action != 'closed' }}
         run: |
-          chmod 777 ${{ env.TEST_RESULTS_PATH }}
+          ls -la ${{ env.TEST_RESULTS_PATH }}
           wget -P ${{ env.TEST_RESULTS_PATH }}  https://zenodo.org/record/4735647/files/resnet50_v1.onnx 
 
       - name: Run performance tests

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -182,7 +182,7 @@ jobs:
           ROCM_BASE: ${{ env.ROCM_BASE }}
           DOCKERIMAGE: rocm-migraphx:${{ inputs.rocm_release }}-${{ env.HASH }}
           BUILD_NAVI: 0
-          TOKEN: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
+          TOKEN: ${{ secrets.gh_token }}
         run: |
           cd $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts
           ./build_migraphx_docker.sh ${{ inputs.benchmark_utils_repo }} ${{ github.event.pull_request.head.repo.full_name }} ${{ env.BRANCH_NAME }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -157,7 +157,7 @@ jobs:
         if: ${{ github.event.action != 'closed' }}
         run: |
           ls -la ${{ env.TEST_RESULTS_PATH }}
-          wget -P ${{ env.TEST_RESULTS_PATH }}  https://zenodo.org/record/4735647/files/resnet50_v1.onnx 
+          wget -P $GITHUB_WORKSPACE/  https://zenodo.org/record/4735647/files/resnet50_v1.onnx 
 
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
@@ -174,7 +174,7 @@ jobs:
           --device=/dev/kfd
           --network=host
           --group-add=video
-          -v ${{ env.TEST_RESULTS_PATH }}:/models:ro
+          -v $GITHUB_WORKSPACE:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -139,10 +139,9 @@ jobs:
         if: ${{ github.event.action != 'closed' }}
         uses: actions/checkout@v6
         with:
-          #repository: ${{ inputs.benchmark_utils_repo }}
-          repository: causten/migraphx-benchmark-utils
+          repository: ${{ inputs.benchmark_utils_repo }}
           path: ${{ env.UTILS_DIR }}
-          token: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
+          ssh-key: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
 
       - name: Calculate HASH
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ env.BRANCH_NAME }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Checkout utils
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -1,4 +1,4 @@
-name: MIGraphX Performance Tests
+name: MIGraphX Performance Tests Reusable
 
 on:
   workflow_call:
@@ -36,59 +36,43 @@ on:
         description: Repository for backup
         required: true
     secrets:
-      gh_token:
-        description: 'Github Access Token'
-        required: true
-      mail_user:
-        description: 'Email username'
-        required: true
-      mail_pass:
-        description: 'Email password'
+      BENCHMARK_UTILS_READ_TOKEN:
+        description: Token with read access to benchmark utils repo
         required: true
 
 env:
   UTILS_DIR: benchmark-utils
-  REPORTS_DIR: migraphx-reports
   DOCKERBASE: rocm-migraphx:${{ inputs.rocm_release }}
   MIOPENTUNE: miopen-dbs/rocm${{ inputs.rocm_release }}
-  MAIL_TO: dl.dl-migraphx-perfrun@amd.com
-  MAIL_CC: igor.mirosavljevic@htecgroup.com
-  MAIL_FROM: GH Actions
-  MAIL_SUBJECT: Nightly Performance run
-  MAIL_BODY: Scheduled Performance test run on develop branch
   PR_ID: ${{ github.event.number }}
   BRANCH_NAME: develop
-  REPORTS_PATH: /usr/share/migraphx/${{ inputs.organization }}/reports
   TEST_RESULTS_PATH: /usr/share/migraphx/${{ inputs.organization }}/test-results
   MIGRAPHX_PATH: /usr/share/migraphx/${{ inputs.organization }}
-  PERFORMANCE_DIR: performance-backup
-
 
 jobs:
   performance_test:
     name: MIGraphX Performance
-    if: ${{ !contains(github.event.pull_request_target.labels.*.name, 'skip bot checks') }}
-    runs-on: [self-hosted,performance]
+    runs-on: ubuntu-latest # [self-hosted, performance]
     outputs:
       git_sha: ${{ steps.git_sha.outputs.git_sha }}
     steps:
       - name: Clean up canceled runs
         continue-on-error: true
         run: |
-          wf_id=$(curl -H "Authorization: token ${{ secrets.gh_token }}" \
+          wf_id=$(curl -H "Authorization: Bearer ${{ github.token }}" \
           ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows \
           | jq -r '.workflows[] | {id, name}| select(.name == "${{ github.workflow }}") | .id')
-          cancel_id=$(curl -H "Authorization: token ${{ secrets.gh_token }}" \
+          cancel_id=$(curl -H "Authorization: Bearer ${{ github.token }}" \
           ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/$wf_id/runs?per_page=10 \
           | jq -r '.workflow_runs[] | {id, run_number, conclusion} | select(.conclusion == "cancelled") | {id, run_number}' \
           | jq -s '.[0].id' || true)
           docker stop perf-test-$cancel_id || true
-          cancel_id=$(curl -H "Authorization: token ${{ secrets.gh_token }}" \
+          cancel_id=$(curl -H "Authorization: Bearer ${{ github.token }}" \
           ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/$wf_id/runs?per_page=10 \
           | jq -r '.workflow_runs[] | {id, run_number, conclusion} | select(.conclusion == "cancelled") | {id, run_number}' \
           | jq -s '.[1].id' || true)
           docker stop perf-test-$cancel_id || true
-          cancel_id=$(curl -H "Authorization: token ${{ secrets.gh_token }}" \
+          cancel_id=$(curl -H "Authorization: Bearer ${{ github.token }}" \
           ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/$wf_id/runs?per_page=10 \
           | jq -r '.workflow_runs[] | {id, run_number, conclusion} | select(.conclusion == "cancelled") | {id, run_number}' \
           | jq -s '.[2].id' || true)
@@ -117,17 +101,8 @@ jobs:
       
       - name: Set GPU parameters
         if: ${{ github.event.action != 'closed' }}
-        run: sudo rocm-smi --device ${{ env.GPU }} --setsrange 700 800 --autorespond y
-      
-      - name: Install python libraries
-        if: ${{ github.event.action != 'closed' }}
-        run: pip install tabulate==0.8.9 pandas==1.4.2 numpy==1.22.3 openpyxl==3.1.2
-
-      - name: Update Mailing list based on organization
-        if: ${{ inputs.organization == 'HTEC' }}
-        run: |
-          echo "MAIL_TO=$(echo "igor.mirosavljevic@htecgroup.com")" >> $GITHUB_ENV
-          echo "MAIL_CC= " >> $GITHUB_ENV
+        run:
+          sudo rocm-smi --device ${{ env.GPU }} --setsrange 700 800 --autorespond y
 
       - name: Update PR env
         if: ${{ github.event_name == 'pull_request_target'}}
@@ -150,7 +125,7 @@ jobs:
         with:
           repository: ${{ inputs.benchmark_utils_repo }}
           path: ${{ env.UTILS_DIR }}
-          token: ${{ secrets.gh_token }}
+          token: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
 
       - name: Calculate HASH
         if: ${{ github.event.action != 'closed' }}
@@ -191,7 +166,7 @@ jobs:
           ROCM_BASE: ${{ env.ROCM_BASE }}
           DOCKERIMAGE: rocm-migraphx:${{ inputs.rocm_release }}-${{ env.HASH }}
           BUILD_NAVI: 0
-          TOKEN: ${{ secrets.gh_token }}
+          TOKEN: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
         run: |
           cd $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts
           ./build_migraphx_docker.sh ${{ inputs.benchmark_utils_repo }} ${{ github.event.pull_request.head.repo.full_name }} ${{ env.BRANCH_NAME }}
@@ -228,6 +203,35 @@ jobs:
           --workdir /migraphx/sh
           migraphx-rocm:${{ inputs.rocm_release }}-${{ steps.git_sha.outputs.git_sha }} /bin/bash -c "./build_migraphx.sh && ./performance_tests.sh ${{ inputs.model_timeout }}"
 
+      - name: Save execution state & smuggle payload
+        if: ${{ github.event.action != 'closed' }}
+        env:
+          FLAGS_INPUT: ${{ inputs.flags }}
+          RESULT_NUMBER_INPUT: ${{ inputs.result_number }}
+          ORGANIZATION_INPUT: ${{ inputs.organization }}
+        run: |
+          mkdir -p ${{ env.TEST_RESULTS_PATH }}
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            echo "${{ github.event.number }}" > ${{ env.TEST_RESULTS_PATH }}/pr_number.txt
+          fi
+
+          echo "RESULT_NUMBER=${RESULT_NUMBER_INPUT:-10}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+          echo "FLAGS=${FLAGS_INPUT:--r}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+          echo "ORGANIZATION=${ORGANIZATION_INPUT:-AMD}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+          echo "GIT_SHA=${{ steps.git_sha.outputs.git_sha }}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+
+          if ls -dt ${{ env.TEST_RESULTS_PATH }}/accuracy* >/dev/null 2>&1; then
+            ACCURACY_DIR=$(ls -dt ${{ env.TEST_RESULTS_PATH }}/accuracy* | head -1 | xargs basename)
+            echo "ACCURACY_DIR=$ACCURACY_DIR" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+          fi
+
+      - name: Upload Artifacts
+        if: ${{ github.event.action != 'closed' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-run-data
+          path: ${{ env.TEST_RESULTS_PATH }}
+
       - name: Delete old images/containers
         if: ${{ github.event_name == 'schedule' }}
         run: |
@@ -239,135 +243,6 @@ jobs:
             docker rmi -f $(docker images --format "{{.Repository}}:{{.Tag}} {{.CreatedAt}}" | grep "rocm-migraphx:${{ inputs.rocm_release }}-"|awk -v date="$(date -d '2 weeks ago' +%Y-%m-%d)" '$2 < date {print $1}') || true
           fi
           docker image prune -f  || true
-
-      - name: Checkout report's repo
-        if: ${{ github.event.action != 'closed' }}
-        uses: actions/checkout@v4.3.1
-        with:
-          repository: ${{ inputs.performance_reports_repo }}
-          path: ${{ env.REPORTS_DIR }}
-          token: ${{ secrets.gh_token }}
-
-      - name: Execute report script
-        if: ${{ github.event_name == 'schedule' }}
-        run: |
-          python3 $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts/report.py \
-          -t '${{ env.TEST_RESULTS_PATH }}' \
-          -r '${{ env.REPORTS_PATH }}'
-          python3 $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts/history.py -n \
-          -t '${{ env.TEST_RESULTS_PATH }}' \
-          -r '${{ env.REPORTS_PATH }}'
-          cp -r ${{ env.REPORTS_PATH }}/results-* $GITHUB_WORKSPACE/${{ env.REPORTS_DIR }}/nightly_reports/
-
-
-      - name: Get latest accuracy results
-        id: accuracy
-        if: ${{ github.event.action != 'closed' }}
-        run: |
-          cd ${{ env.TEST_RESULTS_PATH }}
-          ACCURACY=$(ls -dt accuracy* | head -1)
-          echo "last_test=$ACCURACY" >> $GITHUB_OUTPUT
-      
-      - name: Copy performance results to repo - develop - nightly or manual
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/${{ env.REPORTS_DIR }}/performance_results/develop/${{ steps.git_sha.outputs.git_sha }}
-          cp -r ${{ env.TEST_RESULTS_PATH }}/perf-*/. $GITHUB_WORKSPACE/${{ env.REPORTS_DIR }}/performance_results/develop/${{ steps.git_sha.outputs.git_sha }}
-          cp -r ${{ env.TEST_RESULTS_PATH }}/${{ steps.accuracy.outputs.last_test }}/. $GITHUB_WORKSPACE/${{ env.REPORTS_DIR }}/performance_results/develop/${{ steps.git_sha.outputs.git_sha }}/accuracy_logs
-
-  
-      - name: Copy performance results to repo - PRs
-        if: ${{ github.event_name != 'schedule' && github.event_name == 'pull_request_target' && github.event.action != 'closed'}}
-        run: | 
-          mkdir -p $GITHUB_WORKSPACE/${{ env.REPORTS_DIR }}/performance_results/PRs/PR-$PR_ID/${{ steps.git_sha.outputs.git_sha }}
-          cp -r ${{ env.TEST_RESULTS_PATH }}/perf-*/. $GITHUB_WORKSPACE/${{ env.REPORTS_DIR }}/performance_results/PRs/PR-$PR_ID/${{ steps.git_sha.outputs.git_sha }}
-          cp -r ${{ env.TEST_RESULTS_PATH }}/${{ steps.accuracy.outputs.last_test }}/. $GITHUB_WORKSPACE/${{ env.REPORTS_DIR }}/performance_results/PRs/PR-$PR_ID/${{ steps.git_sha.outputs.git_sha }}/accuracy_logs
-        
-      - name: Push results to repo
-        continue-on-error: true
-        if: ${{ github.event.action != 'closed' }}
-        run: |
-          cd $GITHUB_WORKSPACE/${{ env.REPORTS_DIR }}/
-          git add .
-          git config --local user.email github-actions@github.com
-          git config --local user.name github-actions
-          git commit -m "Performance results run https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" -a
-          git push
-
-      - name: Execute comment script
-        id: auto_comment
-        if: ${{ github.event_name != 'schedule' && github.event_name == 'pull_request_target' && github.event.action != 'closed'}}
-        run: |
-          if [ ${{ inputs.flags }} == "-r" ]; then
-            flagoptions="${{ inputs.flags }} $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts/"
-          else
-            flagoptions="${{ inputs.flags }}"
-          fi 
-          python3 $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts/comment.py -t ${TEST_RESULTS_PATH//-$PR_ID/} -n ${{ inputs.result_number }} $flagoptions -p
-
-      - name: Create a comment on PR
-        if: ${{ github.event_name != 'schedule' && github.event_name == 'pull_request_target' && github.event.action != 'closed'}}
-        uses: marocchino/sticky-pull-request-comment@v2.9.0
-        with:
-          header: performance
-          GITHUB_TOKEN: ${{ secrets.gh_token }}
-          path: ${{ github.workspace }}/${{ env.UTILS_DIR }}/scripts/temp.md
-          recreate: true
-
-      - name: Create accuracy comment on PR
-        if: ${{ github.event_name != 'schedule' && github.event_name == 'pull_request_target' && github.event.action != 'closed'}}
-        uses: marocchino/sticky-pull-request-comment@v2.9.0
-        with:
-          header: accuracy
-          GITHUB_TOKEN: ${{ secrets.gh_token }}
-          path: ${{ env.TEST_RESULTS_PATH }}/${{ steps.accuracy.outputs.last_test }}/results.md
-          recreate: true
-
-      - name: Get latest report
-        id: last_report
-        if: ${{ github.event_name == 'schedule' }}
-        run: |
-          cd ${{ env.REPORTS_PATH }}
-          latest="$(readlink -f $(ls -tp | grep -v /$ | head -1))"
-          echo "latest=$latest" >> $GITHUB_OUTPUT
-
-      - name: Send mail
-        if: ${{ github.event_name == 'schedule' }}
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{ secrets.mail_user }}
-          password: ${{ secrets.mail_pass }}
-          subject: ${{ env.MAIL_SUBJECT }}
-          to: ${{ env.MAIL_TO }}
-          from: ${{ env.MAIL_FROM }}
-          secure: true
-          body: ${{ env.MAIL_BODY }}
-          cc: ${{ env.MAIL_CC }}
-          ignore_cert: true
-          attachments: ${{ steps.last_report.outputs.latest}}
-          priority: normal
-
-      - name : Checkout for backup
-        if: ${{ github.event_name == 'schedule' }}
-        uses: actions/checkout@v4.3.1
-        with:
-          repository: ${{ inputs.performance_backup_repo }}
-          path: ${{ env.PERFORMANCE_DIR }}
-          token: ${{ secrets.gh_token }}
-
-      - name: Backup
-        if: ${{ github.event_name == 'schedule' }}
-        run : |
-          cp -r ${{ env.TEST_RESULTS_PATH }}/perf-* $GITHUB_WORKSPACE/${{ env.PERFORMANCE_DIR }}/${{ inputs.organization }}
-          cd $GITHUB_WORKSPACE/${{ env.PERFORMANCE_DIR }}
-          git add .
-          git status
-          git config --local user.email github-actions@github.com
-          git config --local user.name github-actions
-          git commit -m "Backup latest perf results" -a
-          git push
 
       - name: Reset GPU parameters to default
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -153,6 +153,12 @@ jobs:
           find /mnt/migraphx-perf-work -type d | xargs ls -la ||true
           mount ||true
 
+      - name: Download Resnet50
+         if: ${{ github.event.action != 'closed' }}
+         run: |
+           chmod 777 ${{ env.TEST_RESULTS_PATH }}
+           wget -P ${{ env.TEST_RESULTS_PATH }}  https://zenodo.org/record/4735647/files/resnet50_v1.onnx 
+
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
         run: >
@@ -168,12 +174,12 @@ jobs:
           --device=/dev/kfd
           --network=host
           --group-add=video
-          -v ${{ inputs.model_path }}:/models:ro
+          -v ${{ env.TEST_RESULTS_PATH }}:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && SAVED_MODELS=${{ env.TEST_RESULTS_PATH }} DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} && chmod 777 ${{ env.TEST_RESULTS_PATH }} "
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} "
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -151,6 +151,7 @@ jobs:
           ls -la /mnt/migraphx-perf-work
           echo "results_path=${{ env.TEST_RESULTS_PATH }}<<" >> $GITHUB_ENV ||true
           find /mnt/migraphx-perf-work -type d | xargs ls -la ||true
+          mount ||true
 
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
@@ -172,7 +173,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} && chmod 777 ${{ env.TEST_RESULTS_PATH }} "
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -137,9 +137,10 @@ jobs:
 
       - name: Checkout utils
         if: ${{ github.event.action != 'closed' }}
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v6
         with:
-          repository: ${{ inputs.benchmark_utils_repo }}
+          #repository: ${{ inputs.benchmark_utils_repo }}
+          repository: causten/migraphx-benchmark-utils
           path: ${{ env.UTILS_DIR }}
           token: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
 

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -173,7 +173,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} && chmod 777 ${{ env.TEST_RESULTS_PATH }} "
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && SAVED_MODELS=$GITHUB_WORKSPACE DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} && chmod 777 ${{ env.TEST_RESULTS_PATH }} "
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -89,6 +89,15 @@ jobs:
           | jq -r '.workflow_runs[] | {id, run_number, conclusion} | select(.conclusion == "cancelled") | {id, run_number}' \
           | jq -s '.[2].id' || true)
           docker stop perf-test-$cancel_id || true
+
+      - name: Get git SHA
+        if: ${{ github.event.action != 'closed' }}
+        id: git_sha
+        run: |
+          cd $GITHUB_WORKSPACE
+          git checkout $BRANCH_NAME
+          SHA=$(git log | head -5 | grep -m 1 "^commit" | awk '{print $2}' | cut -c 1-6)
+          echo "git_sha=$SHA" >> $GITHUB_OUTPUT
       
       - name: Get runner ID
         run: |

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -150,6 +150,7 @@ jobs:
           echo "model_path=${{ inputs.model_path }}" >> $GITHUB_ENV
           ls -la /mnt/migraphx-perf-work
           echo "results_path=${{ env.TEST_RESULTS_PATH }}<<" >> $GITHUB_ENV ||true
+          find /mnt/migraphx-perf-work -type d | xargs ls -la ||true
 
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
@@ -171,7 +172,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && ./performance_tests.sh ${{ inputs.model_timeout }}"
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -144,11 +144,12 @@ jobs:
           ssh-key: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
 
       - name: Little debug
-          run: |
-              ls -la  ${{ inputs.model_path }}
-              echo "model_path=${{ inputs.model_path }}" >> $GITHUB_ENV
-              ls -la env.TEST_RESULTS_PATH
-              echo "results_path=$(echo "env.TEST_RESULTS_PATH")" >> $GITHUB_ENV
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          ls -la  ${{ inputs.model_path }}
+          echo "model_path=${{ inputs.model_path }}" >> $GITHUB_ENV
+          ls -la env.TEST_RESULTS_PATH
+          echo "results_path=$(echo "env.TEST_RESULTS_PATH")" >> $GITHUB_ENV
 
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -143,61 +143,6 @@ jobs:
           path: ${{ env.UTILS_DIR }}
           ssh-key: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
 
-      - name: Calculate HASH
-        if: ${{ github.event.action != 'closed' }}
-        id: hash
-        run: |
-          cd $GITHUB_WORKSPACE
-          git checkout $BRANCH_NAME
-          rocm_hash=$(echo ${{hashFiles('**/Dockerfile', '**/hip-clang.docker', '**/*requirements.txt', '**/requirements-py.txt', '**/install_prereqs.sh', '**/rbuild.ini')}} | cut -c 1-6)
-          echo "HASH=$rocm_hash" >> $GITHUB_ENV
-      
-      - name: Get git SHA
-        if: ${{ github.event.action != 'closed' }}
-        id: git_sha
-        run: |
-          cd $GITHUB_WORKSPACE
-          git checkout $BRANCH_NAME
-          SHA=$(git log | head -5 | grep -m 1 "^commit" | awk '{print $2}' | cut -c 1-6)
-          echo "git_sha=$SHA" >> $GITHUB_OUTPUT
-
-      - name: Check image hash
-        if: ${{ github.event.action != 'closed' }}
-        id: check_hash
-        run: |
-          echo ${{ env.HASH }}
-          echo "DOCKERBASE=rocm-migraphx:${{ inputs.rocm_release }}-${{ env.HASH }}" >> $GITHUB_ENV
-          if [ -z "$(docker images -q rocm-migraphx:${{ inputs.rocm_release }}-${{ env.HASH }})" ]; then
-            echo "Hashes not match, base ROCm image will be rebuilt"
-            echo "image=true" >> $GITHUB_ENV
-          else 
-            echo "Hashes match, continue with existing image"
-            echo "image=false" >> $GITHUB_ENV
-          fi
-
-      - name: Rebuild ROCm base
-        if: ${{ env.image == 'true' }}
-        env:
-          ROCM_RELEASE: ${{ inputs.rocm_release }}
-          ROCM_BASE: ${{ env.ROCM_BASE }}
-          DOCKERIMAGE: rocm-migraphx:${{ inputs.rocm_release }}-${{ env.HASH }}
-          BUILD_NAVI: 0
-          TOKEN: ${{ secrets.gh_token }}
-        run: |
-          cd $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts
-          ./build_migraphx_docker.sh ${{ inputs.benchmark_utils_repo }} ${{ github.event.pull_request.head.repo.full_name }} ${{ env.BRANCH_NAME }}
-
-      - name: Docker build
-        if: ${{ github.event.action != 'closed' }}
-        run: >
-          cd $GITHUB_WORKSPACE/${{ env.UTILS_DIR }} && docker build --no-cache
-          --build-arg BRANCH=${{ env.BRANCH_NAME }} 
-          --build-arg DOCKERBASE=${{ env.DOCKERBASE }}
-          --build-arg MIOPENTUNE=${{ env.MIOPENTUNE }}
-          --build-arg benchmark_utils_repo=${{ inputs.benchmark_utils_repo }}
-          -t "migraphx-rocm:${{ inputs.rocm_release }}-${{ steps.git_sha.outputs.git_sha }}" 
-          -f dockerfiles/Daily.Dockerfile .
-
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
         run: >
@@ -216,8 +161,9 @@ jobs:
           -v ${{ inputs.model_path }}:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
+          -v $GITHUB_WORKSPACE/AMDMIGraphX:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          migraphx-rocm:${{ inputs.rocm_release }}-${{ steps.git_sha.outputs.git_sha }} /bin/bash -c "./build_migraphx.sh && ./performance_tests.sh ${{ inputs.model_timeout }}"
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./build_migraphx.sh && ./performance_tests.sh ${{ inputs.model_timeout }}"
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -143,6 +143,10 @@ jobs:
           path: ${{ env.UTILS_DIR }}
           ssh-key: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
 
+      - name: Little Debug
+        run: |
+          ls -l $GITHUB_WORKSPACE
+
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
         run: >
@@ -161,7 +165,7 @@ jobs:
           -v ${{ inputs.model_path }}:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
-          -v $GITHUB_WORKSPACE/AMDMIGraphX:/src/AMDMIGraphX:rw
+          -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
           rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./build_migraphx.sh && ./performance_tests.sh ${{ inputs.model_timeout }}"
 

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -213,7 +213,7 @@ jobs:
           --device=/dev/kfd
           --network=host
           --group-add=video
-          -v ${{ inputs.models_path }}:/models:ro
+          -v ${{ inputs.model_path }}:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           --workdir /migraphx/sh

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -154,10 +154,10 @@ jobs:
           mount ||true
 
       - name: Download Resnet50
-         if: ${{ github.event.action != 'closed' }}
-         run: |
-           chmod 777 ${{ env.TEST_RESULTS_PATH }}
-           wget -P ${{ env.TEST_RESULTS_PATH }}  https://zenodo.org/record/4735647/files/resnet50_v1.onnx 
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          chmod 777 ${{ env.TEST_RESULTS_PATH }}
+          wget -P ${{ env.TEST_RESULTS_PATH }}  https://zenodo.org/record/4735647/files/resnet50_v1.onnx 
 
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -90,15 +90,6 @@ jobs:
           | jq -s '.[2].id' || true)
           docker stop perf-test-$cancel_id || true
 
-      - name: Get git SHA
-        if: ${{ github.event.action != 'closed' }}
-        id: git_sha
-        run: |
-          cd $GITHUB_WORKSPACE
-          git checkout $BRANCH_NAME
-          SHA=$(git log | head -5 | grep -m 1 "^commit" | awk '{print $2}' | cut -c 1-6)
-          echo "git_sha=$SHA" >> $GITHUB_OUTPUT
-      
       - name: Get runner ID
         run: |
           case "$RUNNER_NAME" in
@@ -152,6 +143,15 @@ jobs:
           path: ${{ env.UTILS_DIR }}
           ssh-key: ${{ secrets.BENCHMARK_UTILS_READ_TOKEN }}
 
+      - name: Get git SHA
+        if: ${{ github.event.action != 'closed' }}
+        id: git_sha
+        run: |
+          cd $GITHUB_WORKSPACE
+          git checkout $BRANCH_NAME
+          SHA=$(git log | head -5 | grep -m 1 "^commit" | awk '{print $2}' | cut -c 1-6)
+          echo "git_sha=$SHA" >> $GITHUB_OUTPUT
+      
       - name: Little debug
         if: ${{ github.event.action != 'closed' }}
         run: |

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -101,7 +101,7 @@ jobs:
               GPU=4
               CPU="32-63"
               ;;
-            "linux-migraphx-mi250-1")
+            "${{ inputs.runs_on }}"* | "linux-migraphx-mi250-1"*)
               GPU=0
               CPU="0-31"
               ;;

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -146,11 +146,8 @@ jobs:
       - name: Little debug
         if: ${{ github.event.action != 'closed' }}
         run: |
-          ls -la  ${{ inputs.model_path }}
-          echo "model_path=${{ inputs.model_path }}" >> $GITHUB_ENV
-          ls -la /mnt/migraphx-perf-work
-          echo "results_path=${{ env.TEST_RESULTS_PATH }}<<" >> $GITHUB_ENV ||true
-          find /mnt/migraphx-perf-work -type d | xargs ls -la ||true
+          echo "results_path=${{ env.TEST_RESULTS_PATH }}" >> $GITHUB_ENV ||true
+          find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la ||true
           mount ||true
 
       - name: Download Resnet50
@@ -179,7 +176,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "ls -la /models && ls -la /src/AMDMIGraphX && ./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} "
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "chmod 777 /data/test-results && ./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} "
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -179,7 +179,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} "
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "ls -la /models && ls -la /src/AMDMIGraphX && ./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} "
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -201,7 +201,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}/:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:7.1.1 /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"
+          rocm/migraphx-ci-ubuntu:7.1.1 /bin/bash -c "./build_migraphx.sh && ./performance_tests.sh ${{ inputs.model_timeout }}"
 
       - name: Save execution metadata
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -65,8 +65,11 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       image_tag: ${{ steps.image_hash.outputs.imagetag }}
+      branch_name: ${{ steps.pr_env.outputs.branch_name }}
+      test_results_path: ${{ steps.pr_env.outputs.test_results_path }}
     steps:
       - name: Update PR env
+        id: pr_env
         if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'schedule'}}
         env:
           HEAD_REF: ${{ github.head_ref }}
@@ -77,6 +80,9 @@ jobs:
           sanitized_branch_name=$(echo "$HEAD_REF" | sed 's/[^a-zA-Z0-9._\/]/-/g')
           echo "BRANCH_NAME=$sanitized_branch_name" >> $GITHUB_ENV
           echo "TEST_RESULTS_PATH=$(echo "$TEST_RESULTS_PATH-$PR_ID")" >> $GITHUB_ENV
+
+          echo "branch_name=$sanitized_branch_name" >> $GITHUB_OUTPUT
+          echo "test_results_path=$(echo "$TEST_RESULTS_PATH-$PR_ID")" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         if: ${{ github.event.action != 'closed' }}
@@ -192,6 +198,12 @@ jobs:
         if: ${{ github.event.action != 'closed' }}
         run:
           sudo rocm-smi --device ${{ env.GPU }} --setsrange 700 800 --autorespond y
+
+      - name: Apply PR env from Build
+        if: ${{ needs.build_product.outputs.branch_name != '' }}
+        run: |
+          echo "BRANCH_NAME=${{ needs.build_product.outputs.branch_name }}" >> $GITHUB_ENV
+          echo "TEST_RESULTS_PATH=${{ needs.build_product.outputs.test_results_path }}" >> $GITHUB_ENV
 
       - name: Checkout code
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -108,23 +108,25 @@ jobs:
       - name: Create Image Tag
         id: image_hash
         run: |
+          # NOTE: Changes to this line must also be reflected in ci.yaml to keep behavior consistent
           echo "imagetag=hip-clang-${{hashFiles('**/hip-clang.docker', '**/*requirements.txt', '**/requirements-py.txt', '**/install_prereqs.sh', '**/rbuild.ini')}}" >> $GITHUB_OUTPUT
       
+      # This step polls DockerHub for the CI image built by the ci.yaml workflow (build_image job)
       - name: Wait for CI docker image
         if: ${{ github.event.action != 'closed' }}
         run: |
           TAG="${{ steps.image_hash.outputs.imagetag }}"
           echo "Polling DockerHub for rocm/migraphx-ci-ubuntu:$TAG"
-          for i in {1..40}; do
+          for i in {1..120}; do
             if docker manifest inspect rocm/migraphx-ci-ubuntu:$TAG > /dev/null 2>&1; then
               echo "Docker image is available."
               exit 0
             else
-              echo "Waiting 60 sec... Attempt $i/40"
+              echo "Waiting 60 sec... Attempt $i/120"
               sleep 60
             fi
           done
-          echo "TImeout, waiting for CI to build docker image."
+          echo "Timeout, waiting for CI to build docker image."
           exit 1
 
       - name: Build and Package

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -168,6 +168,8 @@ jobs:
           echo "results_path=${{ env.TEST_RESULTS_PATH }}"
           find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la || true
           ls -l /model_path
+          df -h
+          ls $model_path
 
       - name: Download Resnet50
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -167,10 +167,13 @@ jobs:
         run: |
           echo "results_path=${{ env.TEST_RESULTS_PATH }}"
           echo "model_path=$model_path" 
-          find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la || true
+          ls -l $model_path || true
+          echo "/migraphx-models"
           ls -l /migraphx-models ||true
+          echo "What is inside ${{ env.TEST_RESULTS_PATH }}"
+          find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la || true
+          echo "Show results of df -h"
           df -h || true
-          ls $model_path || true
           mount || true
 
       - name: Download Resnet50

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -268,8 +268,6 @@ jobs:
           -e ROCR_VISIBLE_DEVICES=${{ env.GPU }}
           -e TZ=America/Chicago
           -e TARGET=gpu
-          -e PYTHONPATH=/src/AMDMIGraphX/build/lib
-          -e USE_RBUILD=1
           --device=/dev/dri
           --device=/dev/kfd
           --network=host

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -283,8 +283,12 @@ jobs:
         if: ${{ github.event.action != 'closed' }}
         continue-on-error: true
         run: |
-          OUT=${{ env.TEST_RESULTS_PATH }}/${{ steps.git_sha.outputs.git_sha }}/_env
+          OUT=${{ env.TEST_RESULTS_PATH }}/_env
           mkdir -p "$OUT"
+          {
+            echo "machine_name=$(hostname)"
+            echo "runner_name=${RUNNER_NAME:-}"
+          }                                             > "$OUT/machine.txt"         2>&1 || true
           rocminfo                                      > "$OUT/rocminfo.txt"        2>&1 || true
           sudo rocm-smi -a                              > "$OUT/rocm-smi.txt"        2>&1 || true
           sudo rocm-smi --showtoponuma                  > "$OUT/rocm-topo-numa.txt"  2>&1 || true
@@ -297,6 +301,14 @@ jobs:
           if sudo rocm-smi --showpids -d ${{ env.GPU }} 2>/dev/null | grep -E '^[0-9]+' >/dev/null; then
             echo "::warning::other processes are active on GPU ${{ env.GPU }} -- results may be noisy"
           fi
+
+      - name: Little Debug
+        run: |
+          echo "miopen user-db folder ${{ env.MODEL_PATH }}/../miopen-cache/user-db"
+          ls -la ${{ env.MODEL_PATH }}/../miopen-cache/user-db || true
+          echo "miopen kdb folder ${{ env.MODEL_PATH }}/../miopen-cache/kdb"
+          ls -la ${{ env.MODEL_PATH }}/../miopen-cache/kdb || true
+
 
       - name: Download MIGraphX Deb Artifact
         if: ${{ github.event.action != 'closed' }}
@@ -333,7 +345,7 @@ jobs:
           -v ${{ env.MODEL_PATH }}/../miopen-cache/kdb:/var/miopen/kdb
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:${{ needs.build_product.outputs.image_tag }} /bin/bash -c "apt-get update && apt-get install -y /src/AMDMIGraphX/deb-package/*.deb && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"
+          rocm/migraphx-ci-ubuntu:${{ needs.build_product.outputs.image_tag }} /bin/bash -c "ls -la /var/miopen/user-db && apt-get update && apt-get install -y /src/AMDMIGraphX/deb-package/*.deb && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"
 
       - name: Save execution metadata
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -112,17 +112,6 @@ jobs:
         run:
           sudo rocm-smi --device ${{ env.GPU }} --setsrange 700 800 --autorespond y
 
-      - name: More cleanup
-        if: ${{ github.event.action != 'closed' }}
-        run: |
-          find ${{ inputs.perf_workspace }} -type d -maxdepth 3 |xargs ls -la  || true
-          docker run
-          --name perf-test-$GITHUB_RUN_ID
-          -v ${{ inputs.perf_workspace }}/:/data/test-results
-          -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
-          --workdir /migraphx/sh
-          ubuntu:24.04 -c "rm -rf /data/test-results/*"
-
       - name: Update PR env
         if: ${{ github.event_name == 'pull_request_target'}}
         run: |
@@ -201,19 +190,19 @@ jobs:
           RESULT_NUMBER_INPUT: ${{ inputs.result_number }}
           ORGANIZATION_INPUT: ${{ inputs.organization }}
         run: |
-          mkdir -p ${{ env.TEST_RESULTS_PATH }}
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            echo "${{ github.event.number }}" > ${{ env.TEST_RESULTS_PATH }}/pr_number.txt
+            #docker run --rm -v ${{ env.TEST_RESULTS_PATH }}/:/data alpine sh -c "echo ${{ github.event.number }} > /data/pr_number.txt"
+            sudo echo "${{ github.event.number }}" > ${{ env.TEST_RESULTS_PATH }}/pr_number.txt
           fi
 
-          echo "RESULT_NUMBER=${RESULT_NUMBER_INPUT:-10}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
-          echo "FLAGS=${FLAGS_INPUT:--r}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
-          echo "ORGANIZATION=${ORGANIZATION_INPUT:-AMD}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
-          echo "GIT_SHA=${{ steps.git_sha.outputs.git_sha }}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+          sudo echo "RESULT_NUMBER=${RESULT_NUMBER_INPUT:-10}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+          sudo echo "FLAGS=${FLAGS_INPUT:--r}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+          sudo echo "ORGANIZATION=${ORGANIZATION_INPUT:-AMD}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+          sudo echo "GIT_SHA=${{ steps.git_sha.outputs.git_sha }}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
 
           if ls -dt ${{ env.TEST_RESULTS_PATH }}/accuracy* >/dev/null 2>&1; then
             ACCURACY_DIR=$(ls -dt ${{ env.TEST_RESULTS_PATH }}/accuracy* | head -1 | xargs basename)
-            echo "ACCURACY_DIR=$ACCURACY_DIR" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+            sudo echo "ACCURACY_DIR=$ACCURACY_DIR" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
           fi
 
       - name: Upload Artifacts

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -304,10 +304,10 @@ jobs:
 
       - name: Little Debug
         run: |
-          echo "miopen user-db folder ${{ env.MODEL_PATH }}/../miopen-cache/user-db"
-          ls -la ${{ env.MODEL_PATH }}/../miopen-cache/user-db || true
-          echo "miopen kdb folder ${{ env.MODEL_PATH }}/../miopen-cache/kdb"
-          ls -la ${{ env.MODEL_PATH }}/../miopen-cache/kdb || true
+          echo "miopen user-db folder /mnt/migraphx-perf-work/AMD/miopen-cache/user-db"
+          ls -la /mnt/migraphx-perf-work/AMD/miopen-cache/user-db || true
+          echo "miopen kdb folder /mnt/migraphx-perf-work/AMD/miopen-cache/kdb"
+          ls -la /mnt/migraphx-perf-work/AMD/miopen-cache/kdb || true
 
 
       - name: Download MIGraphX Deb Artifact
@@ -341,8 +341,8 @@ jobs:
           -v ${{ env.MODEL_PATH }}:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}/:/data/test-results
-          -v ${{ env.MODEL_PATH }}/../miopen-cache/user-db:/var/miopen/user-db
-          -v ${{ env.MODEL_PATH }}/../miopen-cache/kdb:/var/miopen/kdb
+          -v /mnt/migraphx-perf-work/AMD/miopen-cache/user-db:/var/miopen/user-db
+          -v /mnt/migraphx-perf-work/AMD/miopen-cache/kdb:/var/miopen/kdb
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
           rocm/migraphx-ci-ubuntu:${{ needs.build_product.outputs.image_tag }} /bin/bash -c "ls -la /var/miopen/user-db && apt-get update && apt-get install -y /src/AMDMIGraphX/deb-package/*.deb && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -103,6 +103,7 @@ jobs:
             "${{ inputs.runs_on }}"* | "linux-migraphx-mi250-1"*)
               GPU=0
               CPU="0-31"
+              MODEL_PATH="/migraphx-models/models"
               ;;
             *)
               echo "Unknown RUNNER_ID: $RUNNER_NAME"
@@ -113,6 +114,7 @@ jobs:
           export CPU
           echo "GPU=$GPU" >> $GITHUB_ENV
           echo "CPU=$CPU" >> $GITHUB_ENV
+          echo "MODEL_PATH=$MODEL_PATH" >> $GITHUB_ENV
 
       - name: Set GPU parameters
         if: ${{ github.event.action != 'closed' }}
@@ -166,12 +168,12 @@ jobs:
         if: ${{ github.event.action != 'closed' }}
         run: |
           echo "results_path=${{ env.TEST_RESULTS_PATH }}"
-          echo "model_path=$model_path" 
-          ls -l $model_path || true
+          echo "model_path=${{ env.MODEL_PATH }}" 
+          ls -l ${{ env.MODEL_PATH }} || true
           echo "/migraphx-models"
           ls -l /migraphx-models ||true
           echo "What is inside /migraphx-models"
-          find /migraphx-models -maxdepth 2 -type d | xargs ls -la || true
+          find /migraphx-models -maxdepth 1 -type d | xargs ls -la || true
           echo "What is inside ${{ env.TEST_RESULTS_PATH }}"
           find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la || true
           echo "Show results of df -h"
@@ -194,7 +196,7 @@ jobs:
           --device=/dev/kfd
           --network=host
           --group-add=video
-          -v /migraphx-models/models:/models:ro
+          -v ${{ env.MODEL_PATH }}:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}/:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -108,10 +108,10 @@ jobs:
       - name: Create Image Tag
         id: image_hash
         run: |
-          # NOTE: Changes to this line must also be reflected in ci.yaml to keep behavior consistent
+          # NOTE: Changes to this line must also be reflected in ROCm/AMDMIGraphX/.github/workflows/ci.yaml to keep behavior consistent
           echo "imagetag=hip-clang-${{hashFiles('**/hip-clang.docker', '**/*requirements.txt', '**/requirements-py.txt', '**/install_prereqs.sh', '**/rbuild.ini')}}" >> $GITHUB_OUTPUT
       
-      # This step polls DockerHub for the CI image built by the ci.yaml workflow (build_image job)
+      # This step polls DockerHub for the CI image built by the ROCm/AMDMIGraphX/.github/workflows/ci.yaml workflow (build_image job)
       - name: Wait for CI docker image
         if: ${{ github.event.action != 'closed' }}
         run: |

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -186,6 +186,7 @@ jobs:
             "${{ inputs.runs_on }}"* | "linux-migraphx-mi250-1"*)
               GPU=0
               CPU="0-31"
+              MEM_NODE=0
               MODEL_PATH="/migraphx-models/models"
               ;;
             *)
@@ -195,14 +196,48 @@ jobs:
           esac
           export GPU
           export CPU
+          export MEM_NODE
           echo "GPU=$GPU" >> $GITHUB_ENV
           echo "CPU=$CPU" >> $GITHUB_ENV
+          echo "MEM_NODE=$MEM_NODE" >> $GITHUB_ENV
           echo "MODEL_PATH=$MODEL_PATH" >> $GITHUB_ENV
 
-      - name: Set GPU parameters
+      # MI250 (gfx90a) stable-perf setup:
+      # - setperfdeterminism caps SCLK at a sustainable boost frequency and
+      #   disables dynamic clock transitions, which is the recommended way to
+      #   eliminate run-to-run variance from DPM / thermal throttling.
+      # - Pin MCLK to the highest DPM state so HBM bandwidth is constant.
+      # - Raise the power cap to package TDP so power isn't the limiter.
+      #
+      # NOTE: this workflow runs on a k8s ARC victim pod which generally does
+      # NOT have the privileges (CAP_SYS_ADMIN / sysfs write) needed by these
+      # rocm-smi calls. Do not fail the run if any step is rejected -- record
+      # the error so the priv setup can be fixed later, and continue with
+      # whatever clock state the runner gave us.
+      - name: Set GPU parameters (MI250 deterministic, best-effort)
         if: ${{ github.event.action != 'closed' }}
-        run:
-          sudo rocm-smi --device ${{ env.GPU }} --setsrange 700 800 --autorespond y
+        continue-on-error: true
+        env:
+          DETERMINISM_SCLK_MHZ: "1700"
+          POWER_CAP_W: "560"
+        run: |
+          # Intentionally NOT using `set -e`: every rocm-smi call is best-effort
+          # because the k8s victim pod may lack privileges to write sysfs.
+          run_smi() {
+            local desc="$1"; shift
+            echo "::group::rocm-smi: $desc"
+            if ! sudo rocm-smi --device ${{ env.GPU }} "$@" --autorespond y 2>&1; then
+              echo "::warning::rocm-smi '$desc' failed (likely insufficient privileges on this runner) -- continuing without it"
+            fi
+            echo "::endgroup::"
+          }
+          run_smi "set perf determinism @ ${DETERMINISM_SCLK_MHZ} MHz" --setperfdeterminism "${DETERMINISM_SCLK_MHZ}"
+          run_smi "pin MCLK to highest DPM state"                      --setmclk 3
+          run_smi "raise power cap to ${POWER_CAP_W}W"                 --setpoweroverdrive "${POWER_CAP_W}"
+          # Always-readable status; useful even when the writes above were rejected.
+          sudo rocm-smi --device ${{ env.GPU }} --showclocks --showpower --showtemp 2>&1 || \
+            rocm-smi --device ${{ env.GPU }} --showclocks --showpower --showtemp 2>&1 || \
+            echo "::warning::could not read GPU status via rocm-smi"
 
       - name: Apply PR env from Build
         if: ${{ needs.build_product.outputs.branch_name != '' }}
@@ -241,21 +276,27 @@ jobs:
           mkdir -p ${{ env.TEST_RESULTS_PATH }}/${{ steps.git_sha.outputs.git_sha }} || true
           echo "TEST_RESULTS_PATH=${{ env.TEST_RESULTS_PATH }}/${{ steps.git_sha.outputs.git_sha }}" >> $GITHUB_ENV
 
-      - name: Little debug
+      # Snapshot driver/clock/topology state alongside the results so any noisy
+      # numbers can be diagnosed after the fact (was the GPU hot? was something
+      # else using it? did the ROCm package versions drift?).
+      - name: Capture system & GPU state for reproducibility
         if: ${{ github.event.action != 'closed' }}
+        continue-on-error: true
         run: |
-          echo "results_path=${{ env.TEST_RESULTS_PATH }}"
-          echo "model_path=${{ env.MODEL_PATH }}" 
-          ls -l ${{ env.MODEL_PATH }} || true
-          echo "/migraphx-models"
-          ls -l /migraphx-models ||true
-          echo "What is inside /migraphx-models"
-          find /migraphx-models -maxdepth 1 -type d | xargs ls -la || true
-          echo "What is inside ${{ env.TEST_RESULTS_PATH }}"
-          find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la || true
-          echo "Show results of df -h"
-          df -h || true
-          mount || true
+          OUT=${{ env.TEST_RESULTS_PATH }}/${{ steps.git_sha.outputs.git_sha }}/_env
+          mkdir -p "$OUT"
+          rocminfo                                      > "$OUT/rocminfo.txt"        2>&1 || true
+          sudo rocm-smi -a                              > "$OUT/rocm-smi.txt"        2>&1 || true
+          sudo rocm-smi --showtoponuma                  > "$OUT/rocm-topo-numa.txt"  2>&1 || true
+          sudo rocm-smi --showpids                      > "$OUT/rocm-smi-pids.txt"   2>&1 || true
+          rocm-bandwidth-test -t 2>/dev/null            > "$OUT/rocm-bw.txt"         2>&1 || true
+          uname -a                                      > "$OUT/uname.txt"           2>&1 || true
+          numactl --hardware 2>/dev/null                > "$OUT/numa.txt"            2>&1 || true
+          dpkg -l 'rocm*' 'hip*' 'miopen*' 'rccl*' 2>/dev/null \
+                                                        > "$OUT/rocm-pkgs.txt"       2>&1 || true
+          if sudo rocm-smi --showpids -d ${{ env.GPU }} 2>/dev/null | grep -E '^[0-9]+' >/dev/null; then
+            echo "::warning::other processes are active on GPU ${{ env.GPU }} -- results may be noisy"
+          fi
 
       - name: Download MIGraphX Deb Artifact
         if: ${{ github.event.action != 'closed' }}
@@ -270,9 +311,17 @@ jobs:
           docker run
           --name perf-test-$GITHUB_RUN_ID
           --cpuset-cpus=${{ env.CPU }}
+          --cpuset-mems=${{ env.MEM_NODE }}
+          --shm-size=8g
+          --ulimit memlock=-1:-1
           -e ROCR_VISIBLE_DEVICES=${{ env.GPU }}
+          -e HIP_VISIBLE_DEVICES=0
           -e TZ=America/Chicago
           -e TARGET=gpu
+          -e HIP_FORCE_DEV_KERNARG=1
+          -e MIOPEN_FIND_MODE=NORMAL
+          -e MIOPEN_USER_DB_PATH=/var/miopen/user-db
+          -e MIOPEN_CUSTOM_CACHE_DIR=/var/miopen/kdb
           --device=/dev/dri
           --device=/dev/kfd
           --network=host
@@ -280,6 +329,8 @@ jobs:
           -v ${{ env.MODEL_PATH }}:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}/:/data/test-results
+          -v ${{ env.MODEL_PATH }}/../miopen-cache/user-db:/var/miopen/user-db
+          -v ${{ env.MODEL_PATH }}/../miopen-cache/kdb:/var/miopen/kdb
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
           rocm/migraphx-ci-ubuntu:${{ needs.build_product.outputs.image_tag }} /bin/bash -c "apt-get update && apt-get install -y /src/AMDMIGraphX/deb-package/*.deb && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"
@@ -328,9 +379,22 @@ jobs:
           fi
           docker image prune -f  || true
 
-      - name: Reset GPU parameters to default
+      # Best-effort cleanup. The k8s victim pod may not have privileges to
+      # touch GPU clocks/power; in that case there's nothing to reset anyway.
+      - name: Reset GPU parameters to default (best-effort)
         if: ${{ always() && github.event.action != 'closed' }}
-        run: sudo rocm-smi --device ${{ env.GPU }} --resetclocks
+        continue-on-error: true
+        run: |
+          run_smi() {
+            local desc="$1"; shift
+            if ! sudo rocm-smi --device ${{ env.GPU }} "$@" --autorespond y 2>&1; then
+              echo "::warning::rocm-smi reset '$desc' failed (likely insufficient privileges on this runner)"
+            fi
+          }
+          run_smi "reset perf determinism" --resetperfdeterminism
+          run_smi "reset power overdrive"  --resetpoweroverdrive
+          run_smi "reset clocks"           --resetclocks
+          run_smi "set perf level auto"    --setperflevel auto
 
       - name: Clean closed PR data
         if: ${{ github.event.action == 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -60,9 +60,81 @@ env:
   TEST_RESULTS_PATH: ${{ inputs.perf_workspace }}/${{ inputs.organization }}/test-results
 
 jobs:
-  performance_test:
+  build_product:
+    name: Build MIGraphX
+    runs-on: ubuntu-24.04
+    outputs:
+      image_tag: ${{ steps.image_hash.outputs.imagetag }}
+    steps:
+      - name: Update PR env
+        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'schedule'}}
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ -z "$PR_ID" ]; then
+            PR_ID="develop"
+          fi
+          sanitized_branch_name=$(echo "$HEAD_REF" | sed 's/[^a-zA-Z0-9._\/]/-/g')
+          echo "BRANCH_NAME=$sanitized_branch_name" >> $GITHUB_ENV
+          echo "TEST_RESULTS_PATH=$(echo "$TEST_RESULTS_PATH-$PR_ID")" >> $GITHUB_ENV
+
+      - name: Checkout code
+        if: ${{ github.event.action != 'closed' }}
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ env.BRANCH_NAME }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - name: Free space and setup swap
+        if: ${{ github.event.action != 'closed' }}
+        uses: jlumbroso/free-disk-space@main
+        continue-on-error: true
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+          docker-images: true
+
+      - name: Create Image Tag
+        id: image_hash
+        run: |
+          echo "imagetag=hip-clang-${{hashFiles('**/hip-clang.docker', '**/*requirements.txt', '**/requirements-py.txt', '**/install_prereqs.sh', '**/rbuild.ini')}}" >> $GITHUB_OUTPUT
+      
+      - name: Wait for CI docker image
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          TAG="${{ steps.image_hash.outputs.imagetag }}"
+          echo "Polling DockerHub for rocm/migraphx-ci-ubuntu:$TAG"
+          for i in {1..40}; do
+            if docker manifest inspect rocm/migraphx-ci-ubuntu:$TAG > /dev/null 2>&1; then
+              echo "Docker image is available."
+              exit 0
+            else
+              echo "Waiting 60 sec... Attempt $i/40"
+              sleep 60
+            fi
+          done
+          echo "TImeout, waiting for CI to build docker image."
+          exit 1
+
+      - name: Build and Package
+        run: |
+          docker run --rm -v $GITHUB_WORKSPACE:/data -w /data rocm/migraphx-ci-ubuntu:${{ steps.image_hash.outputs.imagetag }} /bin/bash -c "mkdir build && cd build && CXX=/opt/rocm/llvm/bin/clang++ CC=/opt/rocm/llvm/bin/clang cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=gfx90a -DMIGRAPHX_ENABLE_GPU=On .. && make package -j\$(nproc) "
+      
+      - name: Upload package
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: migraphx-deb
+          path: build/*.deb
+
+  test_product:
     name: MIGraphX Performance
     runs-on: ["${{ inputs.runs_on }}"]
+    needs: build_product
     outputs:
       git_sha: ${{ steps.git_sha.outputs.git_sha }}
     steps:
@@ -121,18 +193,6 @@ jobs:
         run:
           sudo rocm-smi --device ${{ env.GPU }} --setsrange 700 800 --autorespond y
 
-      - name: Update PR env
-        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'schedule'}}
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          if [ -z "$PR_ID" ]; then
-            PR_ID="develop"
-          fi
-          sanitized_branch_name=$(echo "$HEAD_REF" | sed 's/[^a-zA-Z0-9._\/]/-/g')
-          echo "BRANCH_NAME=$sanitized_branch_name" >> $GITHUB_ENV
-          echo "TEST_RESULTS_PATH=$(echo "$TEST_RESULTS_PATH-$PR_ID")" >> $GITHUB_ENV
-
       - name: Checkout code
         if: ${{ github.event.action != 'closed' }}
         uses: actions/checkout@v6
@@ -180,7 +240,13 @@ jobs:
           df -h || true
           mount || true
 
-
+      - name: Download MIGraphX Deb Artifact
+        if: ${{ github.event.action != 'closed' }}
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: migraphx-deb
+          path: ${{ github.workspace }}/deb-package
+          
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
         run: >
@@ -201,7 +267,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}/:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:7.1.1 /bin/bash -c "./build_migraphx.sh && ./performance_tests.sh ${{ inputs.model_timeout }}"
+          rocm/migraphx-ci-ubuntu:${{ needs.build_product.outputs.image_tag }} /bin/bash -c "apt-get update && apt-get install -y /src/AMDMIGraphX/deb-package/*.deb && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"
 
       - name: Save execution metadata
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -151,13 +151,42 @@ jobs:
           git checkout $BRANCH_NAME
           SHA=$(git log | head -5 | grep -m 1 "^commit" | awk '{print $2}' | cut -c 1-6)
           echo "git_sha=$SHA" >> $GITHUB_OUTPUT
-      
+
+      - name: Make PR commit hash dir
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          echo "SHA=${{ steps.git_sha.outputs.git_sha }}" >> $GITHUB_ENV ||true
+          mkdir ${{ env.TEST_RESULTS_PATH }}/${{ steps.git_sha.outputs.git_sha }}
+
       - name: Little debug
         if: ${{ github.event.action != 'closed' }}
         run: |
           echo "results_path=${{ env.TEST_RESULTS_PATH }}" >> $GITHUB_ENV ||true
           find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la ||true
           mount ||true
+          echo "SHA=${{ steps.git_sha.outputs.git_sha }}" >> $GITHUB_ENV ||true
+
+      - name: Mini Cleanup
+        if: ${{ github.event.action != 'closed' }}
+        run: >
+          docker run
+          --name perf-test-$GITHUB_RUN_ID
+          --cpuset-cpus=${{ env.CPU }}
+          -e ROCR_VISIBLE_DEVICES=${{ env.GPU }}
+          -e TZ=America/Chicago
+          -e TARGET=gpu
+          -e PYTHONPATH=/src/AMDMIGraphX/build/lib
+          -e USE_RBUILD=1
+          --device=/dev/dri
+          --device=/dev/kfd
+          --network=host
+          --group-add=video
+          -v $GITHUB_WORKSPACE:/models:ro
+          -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
+          -v ${{ env.TEST_RESULTS_PATH }}/${{ steps.git_sha.outputs.git_sha }}:/data/test-results
+          -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
+          --workdir /migraphx/sh
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "rm -rf /data/test-results/*"
 
       - name: Download Resnet50
         if: ${{ github.event.action != 'closed' }}
@@ -185,7 +214,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "rm -rf /data/test-results/ && chmod 777 /data/test-results && ./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} "
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} "
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Build and Package
         if: ${{ github.event.action != 'closed' }}
         run: |
-          docker run --rm -v $GITHUB_WORKSPACE:/data -w /data rocm/migraphx-ci-ubuntu:${{ steps.image_hash.outputs.imagetag }} /bin/bash -c "git config --global --add safe.directory . && mkdir build && cd build && CXX=/opt/rocm/llvm/bin/clang++ CC=/opt/rocm/llvm/bin/clang cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=gfx90a -DMIGRAPHX_ENABLE_GPU=On .. && make package -j\$(nproc) "
+          docker run --rm -v $GITHUB_WORKSPACE:/data -w /data rocm/migraphx-ci-ubuntu:${{ steps.image_hash.outputs.imagetag }} /bin/bash -c "git config --global --add safe.directory . && mkdir build && cd build && CXX=/opt/rocm/llvm/bin/clang++ CC=/opt/rocm/llvm/bin/clang cmake -DCMAKE_PREFIX_PATH=/usr/local -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=gfx90a -DMIGRAPHX_ENABLE_GPU=On .. && make package -j\$(nproc) "
       
       - name: Upload package
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -55,11 +55,9 @@ on:
 env:
   UTILS_DIR: benchmark-utils
   DOCKERBASE: rocm-migraphx:${{ inputs.rocm_release }}
-  MIOPENTUNE: miopen-dbs/rocm${{ inputs.rocm_release }}
   PR_ID: ${{ github.event.number }}
   BRANCH_NAME: develop
   TEST_RESULTS_PATH: ${{ inputs.perf_workspace }}/${{ inputs.organization }}/test-results
-  MIGRAPHX_PATH: ${{ inputs.perf_workspace }}/migraphx/${{ inputs.organization }}
 
 jobs:
   performance_test:
@@ -68,27 +66,36 @@ jobs:
     outputs:
       git_sha: ${{ steps.git_sha.outputs.git_sha }}
     steps:
+      - name: Verify PR trust level
+        if: ${{ github.event_name == 'pull_request_target' }}
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          if [[ "$IS_FORK" != "true" ]]; then
+            echo "Same-repo PR, proceeding."
+            exit 0
+          fi
+          HAS_LABEL=$(curl -sH "Authorization: Bearer ${{ github.token }}" \
+            "${{ github.api_url }}/repos/${{ github.repository }}/issues/$PR_NUMBER/labels" \
+            | jq -r '.[].name' | grep -c '^ok-to-test$' || true)
+          if [[ "$HAS_LABEL" -eq 0 ]]; then
+            echo "::error::Fork PRs require the 'ok-to-test' label from a maintainer."
+            exit 1
+          fi
+
       - name: Clean up canceled runs
         continue-on-error: true
         run: |
-          wf_id=$(curl -H "Authorization: Bearer ${{ github.token }}" \
-          ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows \
-          | jq -r '.workflows[] | {id, name}| select(.name == "${{ github.workflow }}") | .id')
-          cancel_id=$(curl -H "Authorization: Bearer ${{ github.token }}" \
-          ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/$wf_id/runs?per_page=10 \
-          | jq -r '.workflow_runs[] | {id, run_number, conclusion} | select(.conclusion == "cancelled") | {id, run_number}' \
-          | jq -s '.[0].id' || true)
-          docker stop perf-test-$cancel_id || true
-          cancel_id=$(curl -H "Authorization: Bearer ${{ github.token }}" \
-          ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/$wf_id/runs?per_page=10 \
-          | jq -r '.workflow_runs[] | {id, run_number, conclusion} | select(.conclusion == "cancelled") | {id, run_number}' \
-          | jq -s '.[1].id' || true)
-          docker stop perf-test-$cancel_id || true
-          cancel_id=$(curl -H "Authorization: Bearer ${{ github.token }}" \
-          ${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/$wf_id/runs?per_page=10 \
-          | jq -r '.workflow_runs[] | {id, run_number, conclusion} | select(.conclusion == "cancelled") | {id, run_number}' \
-          | jq -s '.[2].id' || true)
-          docker stop perf-test-$cancel_id || true
+          wf_id=$(curl -sH "Authorization: Bearer ${{ github.token }}" \
+            "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows" \
+            | jq -r '.workflows[] | select(.name == "${{ github.workflow }}") | .id')
+
+          curl -sH "Authorization: Bearer ${{ github.token }}" \
+            "${{ github.api_url }}/repos/${{ github.repository }}/actions/workflows/$wf_id/runs?per_page=10" \
+            | jq -r '.workflow_runs[] | select(.conclusion == "cancelled") | .id' \
+            | head -3 \
+            | while read -r cid; do docker stop "perf-test-$cid" || true; done
 
       - name: Get runner ID
         run: |
@@ -106,22 +113,27 @@ jobs:
           export CPU
           echo "GPU=$GPU" >> $GITHUB_ENV
           echo "CPU=$CPU" >> $GITHUB_ENV
-      
+
       - name: Set GPU parameters
         if: ${{ github.event.action != 'closed' }}
         run:
           sudo rocm-smi --device ${{ env.GPU }} --setsrange 700 800 --autorespond y
 
       - name: Update PR env
-        if: ${{ github.event_name == 'pull_request_target'}}
+        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'schedule'}}
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          sanitized_branch_name=$(echo "${{ github.head_ref }}" | sed 's/[^a-zA-Z0-9._\/]/-/g')
+          if [ -z "$PR_ID" ]; then
+            PR_ID="develop"
+          fi
+          sanitized_branch_name=$(echo "$HEAD_REF" | sed 's/[^a-zA-Z0-9._\/]/-/g')
           echo "BRANCH_NAME=$sanitized_branch_name" >> $GITHUB_ENV
           echo "TEST_RESULTS_PATH=$(echo "$TEST_RESULTS_PATH-$PR_ID")" >> $GITHUB_ENV
 
       - name: Checkout code
         if: ${{ github.event.action != 'closed' }}
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.BRANCH_NAME }}
@@ -153,13 +165,13 @@ jobs:
       - name: Little debug
         if: ${{ github.event.action != 'closed' }}
         run: |
-          echo "results_path=${{ env.TEST_RESULTS_PATH }}" >> $GITHUB_OUTPUT
-          find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la ||true
+          echo "results_path=${{ env.TEST_RESULTS_PATH }}"
+          find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la || true
 
       - name: Download Resnet50
         if: ${{ github.event.action != 'closed' }}
         run: |
-          wget -P $GITHUB_WORKSPACE/  https://zenodo.org/record/4735647/files/resnet50_v1.onnx 
+          wget -P $GITHUB_WORKSPACE/ https://zenodo.org/record/4735647/files/resnet50_v1.onnx
 
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
@@ -181,35 +193,36 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}/:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:7.1.1 /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh 30m "
+          rocm/migraphx-ci-ubuntu:7.1.1 /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"
 
-      - name: Save execution state & smuggle payload
+      - name: Save execution metadata
         if: ${{ github.event.action != 'closed' }}
         env:
           FLAGS_INPUT: ${{ inputs.flags }}
           RESULT_NUMBER_INPUT: ${{ inputs.result_number }}
           ORGANIZATION_INPUT: ${{ inputs.organization }}
+          EVENT_NUMBER: ${{ github.event.number }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            docker run --rm -v ${{ env.TEST_RESULTS_PATH }}/:/data alpine sh -c "echo ${{ github.event.number }} > /data/pr_number.txt"
-            #sudo echo "${{ github.event.number }}" > ${{ env.TEST_RESULTS_PATH }}/pr_number.txt
+          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+            docker run --rm -v ${{ env.TEST_RESULTS_PATH }}/:/data alpine sh -c "echo $EVENT_NUMBER > /data/pr_number.txt"
           fi
-           
+
           echo "RESULT_NUMBER=${RESULT_NUMBER_INPUT:-10}" >> env_vars.env
           echo "FLAGS=${FLAGS_INPUT:--r}" >> env_vars.env
           echo "ORGANIZATION=${ORGANIZATION_INPUT:-AMD}" >> env_vars.env
-          echo "GIT_SHA=${{ steps.git_sha.outputs.git_sha }}" env_vars.env
+          echo "GIT_SHA=${{ steps.git_sha.outputs.git_sha }}" >> env_vars.env
 
           if ls -dt ${{ env.TEST_RESULTS_PATH }}/accuracy* >/dev/null 2>&1; then
             ACCURACY_DIR=$(ls -dt ${{ env.TEST_RESULTS_PATH }}/accuracy* | head -1 | xargs basename)
-            sudo echo "ACCURACY_DIR=$ACCURACY_DIR" >> env_vars.env
+            echo "ACCURACY_DIR=$ACCURACY_DIR" >> env_vars.env
           fi
 
           docker run --rm -v ${{ env.TEST_RESULTS_PATH }}/:/data -v ./:/src alpine cp -r /src/env_vars.env /data
 
       - name: Upload Artifacts
         if: ${{ github.event.action != 'closed' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: performance-run-data
           path: ${{ env.TEST_RESULTS_PATH }}
@@ -227,9 +240,9 @@ jobs:
           docker image prune -f  || true
 
       - name: Reset GPU parameters to default
-        if: ${{ github.event.action != 'closed' }}
+        if: ${{ always() && github.event.action != 'closed' }}
         run: sudo rocm-smi --device ${{ env.GPU }} --resetclocks
-        
+
       - name: Clean closed PR data
         if: ${{ github.event.action == 'closed' }}
         run: |

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -181,7 +181,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}/:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh 30m "
+          rocm/migraphx-ci-ubuntu:7.1.1 /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh 30m "
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -185,7 +185,7 @@ jobs:
           -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "chmod 777 /data/test-results && ./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} "
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "rm -rf /data/test-results/ && chmod 777 /data/test-results && ./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} "
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -191,19 +191,21 @@ jobs:
           ORGANIZATION_INPUT: ${{ inputs.organization }}
         run: |
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            #docker run --rm -v ${{ env.TEST_RESULTS_PATH }}/:/data alpine sh -c "echo ${{ github.event.number }} > /data/pr_number.txt"
-            sudo echo "${{ github.event.number }}" > ${{ env.TEST_RESULTS_PATH }}/pr_number.txt
+            docker run --rm -v ${{ env.TEST_RESULTS_PATH }}/:/data alpine sh -c "echo ${{ github.event.number }} > /data/pr_number.txt"
+            #sudo echo "${{ github.event.number }}" > ${{ env.TEST_RESULTS_PATH }}/pr_number.txt
           fi
-
-          sudo echo "RESULT_NUMBER=${RESULT_NUMBER_INPUT:-10}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
-          sudo echo "FLAGS=${FLAGS_INPUT:--r}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
-          sudo echo "ORGANIZATION=${ORGANIZATION_INPUT:-AMD}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
-          sudo echo "GIT_SHA=${{ steps.git_sha.outputs.git_sha }}" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+           
+          echo "RESULT_NUMBER=${RESULT_NUMBER_INPUT:-10}" >> env_vars.env
+          echo "FLAGS=${FLAGS_INPUT:--r}" >> env_vars.env
+          echo "ORGANIZATION=${ORGANIZATION_INPUT:-AMD}" >> env_vars.env
+          echo "GIT_SHA=${{ steps.git_sha.outputs.git_sha }}" env_vars.env
 
           if ls -dt ${{ env.TEST_RESULTS_PATH }}/accuracy* >/dev/null 2>&1; then
             ACCURACY_DIR=$(ls -dt ${{ env.TEST_RESULTS_PATH }}/accuracy* | head -1 | xargs basename)
-            sudo echo "ACCURACY_DIR=$ACCURACY_DIR" >> ${{ env.TEST_RESULTS_PATH }}/env_vars.env
+            sudo echo "ACCURACY_DIR=$ACCURACY_DIR" >> env_vars.env
           fi
+
+          docker run --rm -v ${{ env.TEST_RESULTS_PATH }}/:/data -v ./:/src alpine cp -r /src/env_vars.env /data
 
       - name: Upload Artifacts
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -170,6 +170,8 @@ jobs:
           ls -l $model_path || true
           echo "/migraphx-models"
           ls -l /migraphx-models ||true
+          echo "What is inside /migraphx-models"
+          find /migraphx-models -maxdepth 2 -type d | xargs ls -la || true
           echo "What is inside ${{ env.TEST_RESULTS_PATH }}"
           find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la || true
           echo "Show results of df -h"
@@ -192,7 +194,7 @@ jobs:
           --device=/dev/kfd
           --network=host
           --group-add=video
-          -v /migraphx-models:/models:ro
+          -v /migraphx-models/models:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}/:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -107,6 +107,7 @@ jobs:
 
       - name: Create Image Tag
         id: image_hash
+        if: ${{ github.event.action != 'closed' }}
         run: |
           # NOTE: Changes to this line must also be reflected in ROCm/AMDMIGraphX/.github/workflows/ci.yaml to keep behavior consistent
           echo "imagetag=hip-clang-${{hashFiles('**/hip-clang.docker', '**/*requirements.txt', '**/requirements-py.txt', '**/install_prereqs.sh', '**/rbuild.ini')}}" >> $GITHUB_OUTPUT
@@ -130,10 +131,12 @@ jobs:
           exit 1
 
       - name: Build and Package
+        if: ${{ github.event.action != 'closed' }}
         run: |
           docker run --rm -v $GITHUB_WORKSPACE:/data -w /data rocm/migraphx-ci-ubuntu:${{ steps.image_hash.outputs.imagetag }} /bin/bash -c "mkdir build && cd build && CXX=/opt/rocm/llvm/bin/clang++ CC=/opt/rocm/llvm/bin/clang cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=gfx90a -DMIGRAPHX_ENABLE_GPU=On .. && make package -j\$(nproc) "
       
       - name: Upload package
+        if: ${{ github.event.action != 'closed' }}
         uses: actions/upload-artifact@v7.0.1
         with:
           name: migraphx-deb

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -112,6 +112,17 @@ jobs:
         run:
           sudo rocm-smi --device ${{ env.GPU }} --setsrange 700 800 --autorespond y
 
+      - name: More cleanup
+        if: ${{ github.event.action != 'closed' }}
+        run: |
+          find ${{ inputs.perf_workspace }} -type d -maxdepth 3 |xargs ls -la  || true
+          docker run
+          --name perf-test-$GITHUB_RUN_ID
+          -v ${{ inputs.perf_workspace }}/:/data/test-results
+          -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
+          --workdir /migraphx/sh
+          ubuntu:24.04 -c "rm -rf /data/test-results/*"
+
       - name: Update PR env
         if: ${{ github.event_name == 'pull_request_target'}}
         run: |

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -38,15 +38,15 @@ on:
       model_path:
         type: string
         description: Host path to NFS-backed models (ARC runner mount)
-        required: false
+        required: true
       perf_workspace:
         type: string
         description: Writable NFS-backed workspace for reports/scratch (ARC runner mount)
-        required: false
+        required: true
       runs_on:
         type: string
         description: Self-hosted runner label (ARC scale set linux-migraphx-mi250-1)
-        required: false
+        required: true
     secrets:
       BENCHMARK_UTILS_READ_TOKEN:
         description: Token with read access to benchmark utils repo
@@ -93,14 +93,6 @@ jobs:
       - name: Get runner ID
         run: |
           case "$RUNNER_NAME" in
-            "c13-38_0")
-              GPU=0
-              CPU="0-31"
-              ;;
-            "c13-38_4")
-              GPU=4
-              CPU="32-63"
-              ;;
             "${{ inputs.runs_on }}"* | "linux-migraphx-mi250-1"*)
               GPU=0
               CPU="0-31"
@@ -149,49 +141,24 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           git checkout $BRANCH_NAME
-          SHA=$(git log | head -5 | grep -m 1 "^commit" | awk '{print $2}' | cut -c 1-6)
+          SHA=$(git rev-parse --short=6 HEAD)
           echo "git_sha=$SHA" >> $GITHUB_OUTPUT
 
       - name: Make PR commit hash dir
         if: ${{ github.event.action != 'closed' }}
         run: |
-          echo "SHA=${{ steps.git_sha.outputs.git_sha }}" >> $GITHUB_ENV ||true
-          mkdir ${{ env.TEST_RESULTS_PATH }}/${{ steps.git_sha.outputs.git_sha }}
+          mkdir -p ${{ env.TEST_RESULTS_PATH }}/${{ steps.git_sha.outputs.git_sha }} || true
+          echo "TEST_RESULTS_PATH=${{ env.TEST_RESULTS_PATH }}/${{ steps.git_sha.outputs.git_sha }}" >> $GITHUB_ENV
 
       - name: Little debug
         if: ${{ github.event.action != 'closed' }}
         run: |
-          echo "results_path=${{ env.TEST_RESULTS_PATH }}" >> $GITHUB_ENV ||true
+          echo "results_path=${{ env.TEST_RESULTS_PATH }}" >> $GITHUB_OUTPUT
           find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la ||true
-          mount ||true
-          echo "SHA=${{ steps.git_sha.outputs.git_sha }}" >> $GITHUB_ENV ||true
-
-      - name: Mini Cleanup
-        if: ${{ github.event.action != 'closed' }}
-        run: >
-          docker run
-          --name perf-test-$GITHUB_RUN_ID
-          --cpuset-cpus=${{ env.CPU }}
-          -e ROCR_VISIBLE_DEVICES=${{ env.GPU }}
-          -e TZ=America/Chicago
-          -e TARGET=gpu
-          -e PYTHONPATH=/src/AMDMIGraphX/build/lib
-          -e USE_RBUILD=1
-          --device=/dev/dri
-          --device=/dev/kfd
-          --network=host
-          --group-add=video
-          -v $GITHUB_WORKSPACE:/models:ro
-          -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
-          -v ${{ env.TEST_RESULTS_PATH }}/${{ steps.git_sha.outputs.git_sha }}:/data/test-results
-          -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
-          --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "rm -rf /data/test-results/*"
 
       - name: Download Resnet50
         if: ${{ github.event.action != 'closed' }}
         run: |
-          ls -la ${{ env.TEST_RESULTS_PATH }}
           wget -P $GITHUB_WORKSPACE/  https://zenodo.org/record/4735647/files/resnet50_v1.onnx 
 
       - name: Run performance tests
@@ -211,10 +178,10 @@ jobs:
           --group-add=video
           -v $GITHUB_WORKSPACE:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
-          -v ${{ env.TEST_RESULTS_PATH }}:/data/test-results
+          -v ${{ env.TEST_RESULTS_PATH }}/:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }} "
+          rocm/migraphx-ci-ubuntu:latest /bin/bash -c "./install_migraphx.sh && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh 30m "
 
       - name: Save execution state & smuggle payload
         if: ${{ github.event.action != 'closed' }}
@@ -253,7 +220,7 @@ jobs:
             docker rmi -f $(docker images --filter=reference="migraphx-rocm:${{ inputs.rocm_release }}-*" | awk 'NR>1 {print $3}')  || true
           fi
           if [[ $(docker images --format "{{.Repository}}:{{.Tag}} {{.CreatedAt}}" | grep "rocm-migraphx:${{ inputs.rocm_release }}-"|awk -v date="$(date -d '1 week ago' +%Y-%m-%d)" '$2 < date {print $1}') ]]; then
-            docker rmi -f $(docker images --format "{{.Repository}}:{{.Tag}} {{.CreatedAt}}" | grep "rocm-migraphx:${{ inputs.rocm_release }}-"|awk -v date="$(date -d '2 weeks ago' +%Y-%m-%d)" '$2 < date {print $1}') || true
+            docker rmi -f $(docker images --format "{{.Repository}}:{{.Tag}} {{.CreatedAt}}" | grep "rocm-migraphx:${{ inputs.rocm_release }}-"|awk -v date="$(date -d '1 weeks ago' +%Y-%m-%d)" '$2 < date {print $1}') || true
           fi
           docker image prune -f  || true
 

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -166,11 +166,12 @@ jobs:
         if: ${{ github.event.action != 'closed' }}
         run: |
           echo "results_path=${{ env.TEST_RESULTS_PATH }}"
+          echo "model_path=$model_path" 
           find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la || true
           ls -l /migraphx-models ||true
           df -h || true
           ls $model_path || true
-          echo $model_path
+          mount || true
 
       - name: Download Resnet50
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -167,6 +167,7 @@ jobs:
         run: |
           echo "results_path=${{ env.TEST_RESULTS_PATH }}"
           find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la || true
+          ls -l /model_path
 
       - name: Download Resnet50
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -176,10 +176,6 @@ jobs:
           df -h || true
           mount || true
 
-      - name: Download Resnet50
-        if: ${{ github.event.action != 'closed' }}
-        run: |
-          wget -P $GITHUB_WORKSPACE/ https://zenodo.org/record/4735647/files/resnet50_v1.onnx
 
       - name: Run performance tests
         if: ${{ github.event.action != 'closed' }}
@@ -196,7 +192,7 @@ jobs:
           --device=/dev/kfd
           --network=host
           --group-add=video
-          -v $GITHUB_WORKSPACE:/models:ro
+          -v /migraphx-models:/models:ro
           -v $GITHUB_WORKSPACE/${{ env.UTILS_DIR }}/scripts:/migraphx/sh:ro
           -v ${{ env.TEST_RESULTS_PATH }}/:/data/test-results
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -345,7 +345,7 @@ jobs:
           -v /mnt/migraphx-perf-work/AMD/miopen-cache/kdb:/var/miopen/kdb
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:${{ needs.build_product.outputs.image_tag }} /bin/bash -c "ls -la /var/miopen/user-db && apt-get update && apt-get install -y /src/AMDMIGraphX/deb-package/*.deb && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"
+          rocm/migraphx-ci-ubuntu:${{ needs.build_product.outputs.image_tag }} /bin/bash -c "ls -la /var/miopen/user-db && apt-get update && apt-get install -y /src/AMDMIGraphX/deb-package/*.deb && DRIVER=\$(find /opt/rocm -type f -path '*/bin/migraphx-driver' -print -quit) && test -x \"\$DRIVER\" && DRIVER=\"\$DRIVER\" ./performance_tests.sh ${{ inputs.model_timeout }}"
 
       - name: Save execution metadata
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -167,9 +167,10 @@ jobs:
         run: |
           echo "results_path=${{ env.TEST_RESULTS_PATH }}"
           find ${{ env.TEST_RESULTS_PATH }} -maxdepth 2 -type d | xargs ls -la || true
-          ls -l /model_path
-          df -h
-          ls $model_path
+          ls -l /migraphx-models ||true
+          df -h || true
+          ls $model_path || true
+          echo $model_path
 
       - name: Download Resnet50
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Build and Package
         if: ${{ github.event.action != 'closed' }}
         run: |
-          docker run --rm -v $GITHUB_WORKSPACE:/data -w /data rocm/migraphx-ci-ubuntu:${{ steps.image_hash.outputs.imagetag }} /bin/bash -c "mkdir build && cd build && CXX=/opt/rocm/llvm/bin/clang++ CC=/opt/rocm/llvm/bin/clang cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=gfx90a -DMIGRAPHX_ENABLE_GPU=On .. && make package -j\$(nproc) "
+          docker run --rm -v $GITHUB_WORKSPACE:/data -w /data rocm/migraphx-ci-ubuntu:${{ steps.image_hash.outputs.imagetag }} /bin/bash -c "git config --global --add safe.directory . && mkdir build && cd build && CXX=/opt/rocm/llvm/bin/clang++ CC=/opt/rocm/llvm/bin/clang cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=gfx90a -DMIGRAPHX_ENABLE_GPU=On .. && make package -j\$(nproc) "
       
       - name: Upload package
         if: ${{ github.event.action != 'closed' }}


### PR DESCRIPTION
## Motivation

When running the perf test, `timeout: failed to run command ‘/opt/rocm/bin/migraphx-driver’: No such file or directory`

## Technical Details

set migraphx-driver dynamically by finding the path in /opt/rocm instead of using the fixed one

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
