### PR TITLE
set migraphx-driver dynamically by finding the path in /opt/rocm instead of using the fixed one

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -345,7 +345,7 @@ jobs:
           -v /mnt/migraphx-perf-work/AMD/miopen-cache/kdb:/var/miopen/kdb
           -v $GITHUB_WORKSPACE/:/src/AMDMIGraphX:rw
           --workdir /migraphx/sh
-          rocm/migraphx-ci-ubuntu:${{ needs.build_product.outputs.image_tag }} /bin/bash -c "ls -la /var/miopen/user-db && apt-get update && apt-get install -y /src/AMDMIGraphX/deb-package/*.deb && DRIVER=/opt/rocm/bin/migraphx-driver ./performance_tests.sh ${{ inputs.model_timeout }}"
+          rocm/migraphx-ci-ubuntu:${{ needs.build_product.outputs.image_tag }} /bin/bash -c "ls -la /var/miopen/user-db && apt-get update && apt-get install -y /src/AMDMIGraphX/deb-package/*.deb && DRIVER=\$(find /opt/rocm -type f -path '*/bin/migraphx-driver' -print -quit) && test -x \"\$DRIVER\" && DRIVER=\"\$DRIVER\" ./performance_tests.sh ${{ inputs.model_timeout }}"
 
       - name: Save execution metadata
         if: ${{ github.event.action != 'closed' }}


### PR DESCRIPTION
## Motivation

When running the perf test, `timeout: failed to run command ‘/opt/rocm/bin/migraphx-driver’: No such file or directory`

## Technical Details

set migraphx-driver dynamically by finding the path in /opt/rocm instead of using the fixed one

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
